### PR TITLE
Patch - add SQL format

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ The additional payloads added to the flow, and their typical content format are;
 * msg.myepoch: "1536691877064"
 * msg.myrawdate: "2018-09-11T18:51:17.064Z"
 * msg.mypm: "PM"
+* msg.mysqldt: "2018-09-11 18:51:17"
 
 To introduce any of the messages into a flow, simply assign any, or any combination of the messages into a variable, such as; <code>var seconds = msg.myseconds;</code> or to use in a ui_text node add via mustache <code>{{mytimes}}</code>  
 More advanced date formats can also be constructed, such as <code>{{mytime}}hrs - {{mydom}}/{{mymonth}}</code> to get "20:10hrs - 11/Sep", or <code>{{myhourpm}}:{{myminute}}{{mypm}}</code> to get "8.10PM"

--- a/simpletime.html
+++ b/simpletime.html
@@ -25,7 +25,7 @@
             myepoch: {value:true},
             myrawdate: {value:true},
             mypm: {value:true},
-            mysql: {value:true},
+            mysqldt: {value:true},
         },
         inputs:1,
         outputs:1,
@@ -118,9 +118,9 @@
                 this.mypm = true;
                 $("#node-input-mypm").prop('checked', true);
             }
-            if (this.mysql === undefined) {
-                this.mysql = true;
-                $("#node-input-mysql").prop('checked', true);
+            if (this.mysqldt === undefined) {
+                this.mysqldt = true;
+                $("#node-input-mysqldt").prop('checked', true);
             }
         }
     });
@@ -170,8 +170,8 @@
         $("#node-input-myrawdate").prop('checked', true);
         this.mypm = true;
         $("#node-input-mypm").prop('checked', true);
-	this.mysql = true;
-        $("#node-input-mysql").prop('checked', true);
+	this.mysqldt = true;
+        $("#node-input-mysqldt").prop('checked', true);
     };
     function deselectAll() {
         this.mydate = false;
@@ -216,8 +216,8 @@
         $("#node-input-myrawdate").prop('checked', false);
         this.mypm = false;
         $("#node-input-mypm").prop('checked', false);
-        this.mysql = false;
-        $("#node-input-mysql").prop('checked', false);
+        this.mysqldt = false;
+        $("#node-input-mysqldt").prop('checked', false);
     };
 </script>
 
@@ -321,8 +321,8 @@
                 <label for="node-input-mypm" style="width:30%; display:inline"> mypm e.g. "PM"</label>
             </div>
             <div class="form-row">
-                <input type="checkbox" id="node-input-mysql" style="width:15px;">
-                <label for="node-input-mysql" style="width:30%; display:inline"> mysql e.g. "2018-09-11 18:51:17"</label>
+                <input type="checkbox" id="node-input-mysqldt" style="width:15px;">
+                <label for="node-input-mysqldt" style="width:30%; display:inline"> mysqldt e.g. "2018-09-11 18:51:17"</label>
             </div>
         </div>
     </div>
@@ -369,7 +369,7 @@
       <li>msg.myepoch: "1536691877064"</li>
       <li>msg.myrawdate: "2018-09-11T18:51:17.064Z"</li>
       <li>msg.mypm: "PM"</li>
-      <li>msg.mysql: "SQL format"</li>
+      <li>msg.mysqldt: "2018-09-11 18:51:17"</li>
     </ul>
 <p>To introduce any of the messages into a flow, simply assign any, or any combination of the messages into a variable, such as; <code>var seconds = msg.myseconds;</code>
 or to use in a ui_text node add via mustache <code>{{msg.mytimes}}</code></p>

--- a/simpletime.html
+++ b/simpletime.html
@@ -24,7 +24,8 @@
             mymillis: {value:true},
             myepoch: {value:true},
             myrawdate: {value:true},
-            mypm: {value:true}
+            mypm: {value:true},
+            mysql: {value:true},
         },
         inputs:1,
         outputs:1,
@@ -117,6 +118,10 @@
                 this.mypm = true;
                 $("#node-input-mypm").prop('checked', true);
             }
+            if (this.mysql === undefined) {
+                this.mysql = true;
+                $("#node-input-mysql").prop('checked', true);
+            }
         }
     });
 </script>
@@ -165,6 +170,8 @@
         $("#node-input-myrawdate").prop('checked', true);
         this.mypm = true;
         $("#node-input-mypm").prop('checked', true);
+	this.mysql = true;
+        $("#node-input-mysql").prop('checked', true);
     };
     function deselectAll() {
         this.mydate = false;
@@ -209,6 +216,8 @@
         $("#node-input-myrawdate").prop('checked', false);
         this.mypm = false;
         $("#node-input-mypm").prop('checked', false);
+        this.mysql = false;
+        $("#node-input-mysql").prop('checked', false);
     };
 </script>
 
@@ -311,6 +320,10 @@
                 <input type="checkbox" id="node-input-mypm" style="width:15px;">
                 <label for="node-input-mypm" style="width:30%; display:inline"> mypm e.g. "PM"</label>
             </div>
+            <div class="form-row">
+                <input type="checkbox" id="node-input-mysql" style="width:15px;">
+                <label for="node-input-mysql" style="width:30%; display:inline"> mysql e.g. "2018-09-11 18:51:17"</label>
+            </div>
         </div>
     </div>
 </script>
@@ -335,27 +348,28 @@
     <h3>Details</h3>
     <p>The additional payloads added to the flow, and their typical content format are;</p>
     <ul>
-  <li>msg.mydate: "Tue Sep 11 2018"</li>
-  <li>msg.myymd: "2018-09-11"</li>
-  <li>msg.myyear: "2018"</li>
-  <li>msg.mymonth: "Sep"</li>
-  <li>msg.mymonthf: "September"</li>
-  <li>msg.mymonthn: "09"</li>
-  <li>msg.mydom: "11"</li>
-  <li>msg.mydoy: "86"</li>
-  <li>msg.myday: "Tue"</li>
-  <li>msg.mydayf: "Tuesday"</li>
-  <li>msg.myhourpm: "7"</li>
-  <li>msg.myhour: "19"</li>
-  <li>msg.mytime: "19:51"</li>
-  <li>msg.mytimes: "19:51:17"</li>
-  <li>msg.myminute: "51"</li>
-  <li>msg.myminutes: "51:17"</li>
-  <li>msg.mysecond: "17"</li>
-  <li>msg.mymillis: "985"</li>
-  <li>msg.myepoch: "1536691877064"</li>
-  <li>msg.myrawdate: "2018-09-11T18:51:17.064Z"</li>
-  <li>msg.mypm: "PM"</li>
+      <li>msg.mydate: "Tue Sep 11 2018"</li>
+      <li>msg.myymd: "2018-09-11"</li>
+      <li>msg.myyear: "2018"</li>
+      <li>msg.mymonth: "Sep"</li>
+      <li>msg.mymonthf: "September"</li>
+      <li>msg.mymonthn: "09"</li>
+      <li>msg.mydom: "11"</li>
+      <li>msg.mydoy: "86"</li>
+      <li>msg.myday: "Tue"</li>
+      <li>msg.mydayf: "Tuesday"</li>
+      <li>msg.myhourpm: "7"</li>
+      <li>msg.myhour: "19"</li>
+      <li>msg.mytime: "19:51"</li>
+      <li>msg.mytimes: "19:51:17"</li>
+      <li>msg.myminute: "51"</li>
+      <li>msg.myminutes: "51:17"</li>
+      <li>msg.mysecond: "17"</li>
+      <li>msg.mymillis: "985"</li>
+      <li>msg.myepoch: "1536691877064"</li>
+      <li>msg.myrawdate: "2018-09-11T18:51:17.064Z"</li>
+      <li>msg.mypm: "PM"</li>
+      <li>msg.mysql: "SQL format"</li>
     </ul>
 <p>To introduce any of the messages into a flow, simply assign any, or any combination of the messages into a variable, such as; <code>var seconds = msg.myseconds;</code>
 or to use in a ui_text node add via mustache <code>{{msg.mytimes}}</code></p>

--- a/simpletime.js
+++ b/simpletime.js
@@ -25,6 +25,8 @@ module.exports = function(RED) {
         this.myepoch = (config.myepoch === undefined) ? true : config.myepoch;
         this.myrawdate = (config.myrawdate === undefined) ? true : config.myrawdate;
         this.mypm = (config.mypm === undefined) ? true : config.mypm;
+	this.mysqldt = (config.mysqldt === undefined) ? true : config.mysqldt;
+
 
         node.on('input', function(msg) {
             const monthNames = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
@@ -138,6 +140,9 @@ module.exports = function(RED) {
             };
             if (this.mypm) {
                 msg.mypm = amp;
+            };
+            if (this.mysqldt) {
+                msg.mysqldt = '' + yr + '-' + mnu + '-' + dt + ' ' + hms;
             };
             node.send(msg);
         });


### PR DESCRIPTION
Patch to add SQL DateTime format used in particular with MySQL / MariaDB

msg.mysqldt : YYYY-MM-DD HH:MM:SS£
Example : '2024-09-24 15:30:45'